### PR TITLE
Switch away from jss-recipes identifiers

### DIFF
--- a/Airtame/Airtame.jss.recipe
+++ b/Airtame/Airtame.jss.recipe
@@ -7,7 +7,7 @@
 	<key>Description</key>
 	<string>Downloads the latest version of Airtame and imports it into your JSS.</string>
 	<key>Identifier</key>
-	<string>com.github.jss-recipes.jss.Airtame</string>
+	<string>com.github.tecnico1931.jss.Airtame</string>
 	<key>Input</key>
 	<dict>
 		<key>CATEGORY</key>

--- a/PritunlClient/PritunlClient.jss.recipe
+++ b/PritunlClient/PritunlClient.jss.recipe
@@ -7,7 +7,7 @@
 	<key>Description</key>
 	<string>Downloads the latest version of PritunlClient and imports it into your JSS.</string>
 	<key>Identifier</key>
-	<string>com.github.jss-recipes.jss.PritunlClient</string>
+	<string>com.github.tecnico1931.jss.PritunlClient</string>
 	<key>Input</key>
 	<dict>
 		<key>CATEGORY</key>

--- a/SDM/SDM.jss.recipe
+++ b/SDM/SDM.jss.recipe
@@ -7,7 +7,7 @@
 	<key>Description</key>
 	<string>Downloads the latest version of SDM and imports it into your JSS.</string>
 	<key>Identifier</key>
-	<string>com.github.jss-recipes.jss.SDM</string>
+	<string>com.github.tecnico1931.jss.SDM</string>
 	<key>Input</key>
 	<dict>
 		<key>CATEGORY</key>


### PR DESCRIPTION
Identifiers uniquely identify AutoPkg recipes, and that's why it's conventional to use your GitHub username in recipes you create.

Your JSS recipes use the nomenclature of the [jss-recipes repo](https://github.com/autopkg/jss-recipes) for their identifiers, which increases the chance of identifier collisions. This PR changes your JSS recipes to match your other recipes' identifiers.