### PR TITLE
Update Airtame.download recipe

### DIFF
--- a/Airtame/Airtame.download.recipe
+++ b/Airtame/Airtame.download.recipe
@@ -41,6 +41,8 @@
 				<string>%pathname%/Airtame.app</string>
 				<key>requirement</key>
 				<string>identifier "com.airtame.airtame-application" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4TPSP88HN2"</string>
+				<key>strict_verification</key>
+				<true/>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -48,7 +50,7 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>input_plist_path</key>
+				<key>info_path</key>
 				<string>%pathname%/Airtame.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>

--- a/Airtame/Airtame.download.recipe
+++ b/Airtame/Airtame.download.recipe
@@ -5,13 +5,13 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Airtame.</string>
+	<string>Downloads the latest DMG version of Airtame.</string>
 	<key>Identifier</key>
 	<string>tecnico1931.download.Airtame</string>
 	<key>Input</key>
 	<dict>
 		<key>DOWNLOAD_URL</key>
-		<string>https://downloads-cdn.airtame.com/application/ga/osx_x64/releases/airtame-application-3.1.1.dmg</string>
+		<string>https://downloads-cdn.airtame.com/get.php?platform=osx_x64&amp;_ga</string>
 		<key>NAME</key>
 		<string>Airtame</string>
 	</dict>
@@ -50,11 +50,16 @@
 			<dict>
 				<key>input_plist_path</key>
 				<string>%pathname%/Airtame.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleVersion</string>
+				<key>plist_keys</key>
+				<dict>
+					<key>CFBundleVersion</key>
+					<string>version</string>
+					<key>LSMinimumSystemVersion</key>
+					<string>minimum_os_vers</string>
+				</dict>
 			</dict>
 			<key>Processor</key>
-			<string>Versioner</string>
+			<string>PlistReader</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Current recipe does not download latest available version.  This one now does.

Additionally, switch to use PlistReader instead of versioner in order to collect the min supported os version for use by other recipes.