### PR TITLE
Update Airtame.pkg recipe

### DIFF
--- a/Airtame/Airtame.pkg.recipe
+++ b/Airtame/Airtame.pkg.recipe
@@ -5,25 +5,99 @@
 	<key>Comment</key>
 	<string>Created with Recipe Robot v1.0.5 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
-	<string>Downloads the latest version of Airtame and creates a package.</string>
+	<string>Downloads the latest PKG version of Airtame.</string>
 	<key>Identifier</key>
 	<string>tecnico1931.pkg.Airtame</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.airtame.airtame-application</string>
+		<key>DOWNLOAD_URL</key>
+		<string>https://downloads.airtame.com/get.php?platform=mac&amp;pkg</string>
 		<key>NAME</key>
 		<string>Airtame</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
-	<key>ParentRecipe</key>
-	<string>tecnico1931.download.Airtame</string>
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>filename</key>
+				<string>%NAME%.pkg</string>
+				<key>url</key>
+				<string>%DOWNLOAD_URL%</string>
+			</dict>
 			<key>Processor</key>
-			<string>AppPkgCreator</string>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%</string>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: AIRTAME APS (4TPSP88HN2)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>flat_pkg_path</key>
+				<string>%pathname%</string>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack</string>
+			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>destination_path</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+				<key>pkg_payload_path</key>
+				<string>%RECIPE_CACHE_DIR%/unpack/com.airtame.airtame-application.pkg/Payload</string>
+			</dict>
+			<key>Processor</key>
+			<string>PkgPayloadUnpacker</string>
+		</dict>
+		<dict>
+            <key>Arguments</key>
+            <dict>
+                <key>info_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Airtame.app/Contents/Info.plist</string>
+                <key>plist_keys</key>
+                <dict>
+                    <key>CFBundleVersion</key>
+                    <string>version</string>
+                    <key>LSMinimumSystemVersion</key>
+                    <string>minimum_os_vers</string>
+                </dict>
+            </dict>
+            <key>Processor</key>
+            <string>PlistReader</string>
+        </dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>path_list</key>
+				<array>
+					<string>%RECIPE_CACHE_DIR%/%NAME%</string>
+					<string>%RECIPE_CACHE_DIR%/unpack</string>
+				</array>
+			</dict>
+			<key>Processor</key>
+			<string>PathDeleter</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
Have recipe use PKG distribution from website.  Other changes similar to those made in #5 

- Since drag-and-drop apps distributed via DMGs are generally better for munki and PKGs are generally better for jamf, have this recipe instead grab this PKG since it's signed and notarized, rather than build a PKG from the DMG version
- Add FlatPkgUnpacker and PkgPayloadUnpacker to then allow PlistReader to collect the same CFBundleVersion and min os version from Info.plist
- Delete the temporary directories once processed