### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/SDM/SDM.pkg.recipe
+++ b/SDM/SDM.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.tecnico1931.pkg.SDM</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.electron.sdm</string>
 		<key>NAME</key>
 		<string>SDM</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ SDM/SDM.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/Tecnico1931-recipes/SDM/SDM.pkg.recipe
Processing repos/Tecnico1931-recipes/SDM/SDM.pkg.recipe...
URLDownloader
{'Input': {'filename': 'SDM.dmg',
           'url': 'https://app.strongdm.com/downloads/client/darwin'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/downloads/SDM.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/downloads/SDM.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/downloads/SDM.dmg/SDM.app',
           'requirement': 'identifier "com.electron.sdm" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'W5HSYBBJGA'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/downloads/SDM.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.s3zi7X/SDM.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.s3zi7X/SDM.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.s3zi7X/SDM.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/downloads/SDM.dmg/SDM.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/downloads/SDM.dmg
Versioner: Found version 15.9.0 in file /private/tmp/dmg.F8vTOT/SDM.app/Contents/Info.plist
{'Output': {'version': '15.9.0'}}
AppPkgCreator
{'Input': {'version': '15.9.0'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/downloads/SDM.dmg
AppPkgCreator: Using path '/private/tmp/dmg.zPh1ZB/SDM.app' matched from globbed '/private/tmp/dmg.zPh1ZB/*.app'.
AppPkgCreator: BundleID: com.electron.sdm
AppPkgCreator: Copied /private/tmp/dmg.zPh1ZB/SDM.app to ~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/payload/Applications/SDM.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.electron.sdm',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/SDM-15.9.0.pkg',
                                                        'version': '15.9.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '15.9.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/receipts/SDM.pkg-receipt-20210213-225816.plist

The following packages were built:
    Identifier        Version  Pkg Path                                                                            
    ----------        -------  --------                                                                            
    com.electron.sdm  15.9.0   ~/Library/AutoPkg/Cache/com.github.tecnico1931.pkg.SDM/SDM-15.9.0.pkg  
```

